### PR TITLE
	Slack Icon dictionary made configurable

### DIFF
--- a/README.md
+++ b/README.md
@@ -129,19 +129,21 @@ You can customize the following parameters of slack-notifications :
   * slack_notifications_channel [Default: `#monitoring_alerts`]
   * slack_notifications_botname [Default: `icinga2`]
   * slack_notifications_plugin_output_max_length [Default: `3500`]
-  * slack_notifications_icon_dictionary [Default: ```
-                                            {
-                                                "DOWNTIMEREMOVED" = "leftwards_arrow_with_hook",
-                                                "ACKNOWLEDGEMENT" = "ballot_box_with_check",
-                                                "PROBLEM" = "red_circle",
-                                                "RECOVERY" = "large_blue_circle",
-                                                "DOWNTIMESTART" = "arrow_up_small",
-                                                "DOWNTIMEEND" = "arrow_down_small",
-                                                "FLAPPINGSTART" = "small_red_triangle",
-                                                "FLAPPINGEND" = "small_red_triangle_down",
-                                                "CUSTOM" = "speaking_head_in_silhouette"
-                                            }
-                                          ```]
+  * slack_notifications_icon_dictionary [Default:
+   ```
+     {
+         "DOWNTIMEREMOVED" = "leftwards_arrow_with_hook",
+         "ACKNOWLEDGEMENT" = "ballot_box_with_check",
+         "PROBLEM" = "red_circle",
+         "RECOVERY" = "large_blue_circle",
+         "DOWNTIMESTART" = "arrow_up_small",
+         "DOWNTIMEEND" = "arrow_down_small",
+         "FLAPPINGSTART" = "small_red_triangle",
+         "FLAPPINGEND" = "small_red_triangle_down",
+         "CUSTOM" = "speaking_head_in_silhouette"
+     }
+   ```
+  ]
 
 In order to do so, place the desired parameter into `slack-notifications-user-configuration.conf` file.
 

--- a/README.md
+++ b/README.md
@@ -129,6 +129,19 @@ You can customize the following parameters of slack-notifications :
   * slack_notifications_channel [Default: `#monitoring_alerts`]
   * slack_notifications_botname [Default: `icinga2`]
   * slack_notifications_plugin_output_max_length [Default: `3500`]
+  * slack_notifications_icon_dictionary [Default: ```
+                                            {
+                                                "DOWNTIMEREMOVED" = "leftwards_arrow_with_hook",
+                                                "ACKNOWLEDGEMENT" = "ballot_box_with_check",
+                                                "PROBLEM" = "red_circle",
+                                                "RECOVERY" = "large_blue_circle",
+                                                "DOWNTIMESTART" = "arrow_up_small",
+                                                "DOWNTIMEEND" = "arrow_down_small",
+                                                "FLAPPINGSTART" = "small_red_triangle",
+                                                "FLAPPINGEND" = "small_red_triangle_down",
+                                                "CUSTOM" = "speaking_head_in_silhouette"
+                                            }
+                                          ```]
 
 In order to do so, place the desired parameter into `slack-notifications-user-configuration.conf` file.
 
@@ -161,6 +174,45 @@ template Notification "slack-notifications-user-configuration-services" {
     interval = 3m
     
     vars.slack_notifications_channel = "#monitoring_alerts_for_service"
+}
+```
+
+You can choose to override the whole icon dictionary, or override specific types only:
+
+_Example override the whole icon dictionary_
+
+```
+template Notification "slack-notifications-user-configuration" {
+    import "slack-notifications-default-configuration"
+
+    vars.slack_notifications_webhook_url = "https://hooks.slack.com/services/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"
+    vars.slack_notifications_icinga2_base_url = "http://localhost:80/icingaweb2"
+    vars.slack_notifications_channel = "#icinga2-private-test"
+    vars.slack_notifications_icon_dictionary = {
+       "DOWNTIMEREMOVED" = "leftwards_arrow_with_hook",
+       "ACKNOWLEDGEMENT" = "ballot_box_with_check",
+       "PROBLEM" = "bomb",
+       "RECOVERY" = "large_blue_circle",
+       "DOWNTIMESTART" = "up",
+       "DOWNTIMEEND" = "arrow_double_down",
+       "FLAPPINGSTART" = "small_red_triangle",
+       "FLAPPINGEND" = "small_red_triangle_down",
+       "CUSTOM" = "speaking_head_in_silhouette"
+    }    
+    ...
+```
+
+_Example override specific type_
+```
+template Notification "slack-notifications-user-configuration" {
+    import "slack-notifications-default-configuration"
+
+    vars.slack_notifications_webhook_url = "https://hooks.slack.com/services/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"
+    vars.slack_notifications_icinga2_base_url = "http://localhost:80/icingaweb2"
+    vars.slack_notifications_channel = "#icinga2-private-test"
+
+    vars.slack_notifications_icon_dictionary.CUSTOM = "cherries"
+    ...
 }
 ```
 

--- a/src/slack-notifications/slack-notifications-command.conf
+++ b/src/slack-notifications/slack-notifications-command.conf
@@ -10,12 +10,14 @@ object NotificationCommand "slack-notifications-command" {
     var slack_channel = macro("$slack_notifications_channel$")
     var slack_botname = macro("$slack_notifications_botname$")
     var icinga2_base_url = macro("$slack_notifications_icinga2_base_url$")
+    var slack_icon_dictionary = macro("$slack_notifications_icon_dictionary$")
     var configuration = {
         "vars.slack_notifications_plugin_output_max_length" = plugin_output_max_length,
         "vars.slack_notifications_webhook_url" = slack_webhook_url,
         "vars.slack_notifications_channel" = slack_channel,
         "vars.slack_notifications_botname" = slack_botname,
         "vars.slack_notifications_icinga2_base_url" = icinga2_base_url
+        "vars.slack_notifications_icon_dictionary" = slack_icon_dictionary
     }
     log(LogDebug, "slack-notifications", "Sending notification...read user configuration successfully: " + Json.encode(configuration))
 
@@ -61,18 +63,8 @@ object NotificationCommand "slack-notifications-command" {
     if(notification_type == "CUSTOM"){
         notification_type_custom_text = "(Author: " + notification_author + ", Message: " + notification_comment + ")"
     }
-    var notification_type_to_slack_icon = {
-        "DOWNTIMEREMOVED" = "leftwards_arrow_with_hook",
-        "ACKNOWLEDGEMENT" = "ballot_box_with_check",
-        "PROBLEM" = "red_circle",
-        "RECOVERY" = "large_blue_circle",
-        "DOWNTIMESTART" = "arrow_up_small",
-        "DOWNTIMEEND" = "arrow_down_small",
-        "FLAPPINGSTART" = "small_red_triangle",
-        "FLAPPINGEND" = "small_red_triangle_down",
-        "CUSTOM" = "speaking_head_in_silhouette"
-    }
-    var icon = notification_type_to_slack_icon.get(notification_type)
+
+    var icon = slack_icon_dictionary.get(notification_type)
     log(LogDebug, "slack-notifications", "Sending notification...chose icon successfully: " + icon)
 
     log(LogDebug, "slack-notifications", "Sending notification...generating notification text")

--- a/src/slack-notifications/slack-notifications-configuration.conf
+++ b/src/slack-notifications/slack-notifications-configuration.conf
@@ -12,6 +12,17 @@ template Notification "slack-notifications-default-configuration" {
     vars.slack_notifications_channel = "#monitoring_alerts"
     vars.slack_notifications_botname = "icinga2"
     vars.slack_notifications_plugin_output_max_length = 3500
+    vars.slack_notifications_icon_dictionary = {
+       "DOWNTIMEREMOVED" = "leftwards_arrow_with_hook",
+       "ACKNOWLEDGEMENT" = "ballot_box_with_check",
+       "PROBLEM" = "red_circle",
+       "RECOVERY" = "large_blue_circle",
+       "DOWNTIMESTART" = "arrow_up_small",
+       "DOWNTIMEEND" = "arrow_down_small",
+       "FLAPPINGSTART" = "small_red_triangle",
+       "FLAPPINGEND" = "small_red_triangle_down",
+       "CUSTOM" = "speaking_head_in_silhouette"
+    }
 }
 
 template Notification "slack-notifications-configuration" {


### PR DESCRIPTION
One can now override the icon dictionary through the user configurations. 
BTW changing single dictionary entry also works.

Tested manually inside docker.
