### PR TITLE
Fallback icon when not found

### DIFF
--- a/src/slack-notifications/slack-notifications-command.conf
+++ b/src/slack-notifications/slack-notifications-command.conf
@@ -64,7 +64,11 @@ object NotificationCommand "slack-notifications-command" {
         notification_type_custom_text = "(Author: " + notification_author + ", Message: " + notification_comment + ")"
     }
 
-    var icon = slack_icon_dictionary.get(notification_type)
+    try {
+        var icon = slack_icon_dictionary.get(notification_type)
+    } except {
+        var icon = "bell"
+    }
     log(LogDebug, "slack-notifications", "Sending notification...chose icon successfully: " + icon)
 
     log(LogDebug, "slack-notifications", "Sending notification...generating notification text")


### PR DESCRIPTION
Hi. For some reason I get
``warning/PluginNotificationTask: Notification command for object 'somename!disk' (PID: -1, arguments: 'sh' '-c' '') terminated with exit code 3, output: Error: Argument is not a callable object.``
error when I'm trying to use this project. Here is simple fix of this problem.