### PR TITLE
Add colour for host states

### DIFF
--- a/src/slack-notifications/slack-notifications-configuration.conf
+++ b/src/slack-notifications/slack-notifications-configuration.conf
@@ -14,8 +14,10 @@ template Notification "slack-notifications-default-configuration" {
     vars.slack_notifications_plugin_output_max_length = 3500
     vars.slack_notifications_color_dictionary = {
      "OK" = "good",
+     "UP" = "good",
      "WARNING" = "warning",
      "CRITICAL" = "danger",
+     "DOWN" = "danger,
      "UNKNOWN" = "grey"
     }
     vars.slack_notifications_icon_dictionary = {


### PR DESCRIPTION
It came to my attention that notification for down host didn't have any colour. So I have added them in the template.

Also worth noting that they didn't even had the blue colour as what you might expect looking at the code. This might need to be figured out later.