### PR TITLE
Allow to notify on custom channels

### DIFF
--- a/src/slack-notifications/slack-notifications-configuration.conf
+++ b/src/slack-notifications/slack-notifications-configuration.conf
@@ -9,7 +9,6 @@ template Notification "slack-notifications-default-configuration" {
 
     interval = 5m
 
-    vars.slack_notifications_channel = "#monitoring_alerts"
     vars.slack_notifications_botname = "icinga2"
     vars.slack_notifications_plugin_output_max_length = 3500
     vars.slack_notifications_color_dictionary = {
@@ -58,11 +57,27 @@ template Notification "slack-notifications-default-configuration-hosts" {
 apply Notification "slack-notifications-notification-hosts" to Host {
   import "slack-notifications-user-configuration-hosts"
 
+  vars.slack_notifications_channel = "#monitoring_alerts"
+  
   assign where host.vars.slack_notifications == "enabled"
 }
 
 apply Notification "slack-notifications-notification-services" to Service {
   import "slack-notifications-user-configuration-services"
+  
+  vars.slack_notifications_channel = "#monitoring_alerts"
 
   assign where service.vars.slack_notifications == "enabled"
+}
+
+apply Notification "slack-notifications-notification-hosts" to Host {
+  import "slack-notifications-user-configuration-hosts"
+
+  assign where host.vars.slack_notifications_channel
+}
+
+apply Notification "slack-notifications-notification-services" to Service {
+  import "slack-notifications-user-configuration-services"
+
+  assign where service.vars.slack_notifications_channel
 }


### PR DESCRIPTION
* Move the definition of the var slack_notification_channel from the Template to the Notification
* Apply the Notification (without a default channel) where the var slack_notification_channel is defined in the Host/Service.
     (it assumes such definition as an equivalent of slack_notifications == "enabled", using a custom channel)